### PR TITLE
fix/post-sync-update

### DIFF
--- a/.github/workflows/pull-request-workflow.yaml
+++ b/.github/workflows/pull-request-workflow.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: JDK Version
         run: java --version
       - name: Enable Maven Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -59,7 +59,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/src/main/java/com/webdev/cosmo/cosmobackend/service/internal/posts/PostController.java
+++ b/src/main/java/com/webdev/cosmo/cosmobackend/service/internal/posts/PostController.java
@@ -3,6 +3,7 @@ package com.webdev.cosmo.cosmobackend.service.internal.posts;
 import com.webdev.cosmo.cosmobackend.service.internal.posts.model.Post;
 import com.webdev.cosmo.cosmobackend.service.internal.posts.service.PostService;
 import com.webdev.cosmo.cosmobackend.util.interfaces.*;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.openapitools.model.PostListQueryItem;
 import org.openapitools.model.PostListQueryItemDetails;
@@ -13,7 +14,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -27,7 +27,7 @@ public class PostController {
     private final SimpleQueryService<String, PostListQueryItemDetails> postDetailsQueryService;
 
 
-    @PostMapping("/sync")
+    @PutMapping("/sync")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public void syncPostsWithFacebook() {
         postsSyncExecutor.execute();
@@ -40,6 +40,7 @@ public class PostController {
     }
 
     @GetMapping("/{postId}")
+    @Transactional(readOnly = true)
     public PostListQueryItemDetails getPostById(@PathVariable String postId) {
         return postDetailsQueryService.findBy(postId);
     }

--- a/src/main/java/com/webdev/cosmo/cosmobackend/service/internal/posts/mapper/PostMapper.java
+++ b/src/main/java/com/webdev/cosmo/cosmobackend/service/internal/posts/mapper/PostMapper.java
@@ -2,6 +2,8 @@ package com.webdev.cosmo.cosmobackend.service.internal.posts.mapper;
 
 import com.webdev.cosmo.cosmobackend.service.api.FacebookImage;
 import com.webdev.cosmo.cosmobackend.service.internal.posts.model.Post;
+import com.webdev.cosmo.cosmobackend.service.internal.posts.repository.PostRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
@@ -14,8 +16,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-@Mapper(uses = {FacebookImageMapper.class})
+@Slf4j
+@Mapper(componentModel = "spring", uses = {FacebookImageMapper.class})
 public abstract class PostMapper {
 
     @Autowired
@@ -26,7 +32,6 @@ public abstract class PostMapper {
     public abstract Post map(PostModel postModel);
 
     public abstract PostListQueryItem mapPostListQueryItem(Post post);
-
     public abstract PostListQueryItemDetails mapPostListQueryItemDetails(Post post);
 
     @AfterMapping
@@ -66,34 +71,49 @@ public abstract class PostMapper {
                 .setHeight(value.getHeight()));
     }
 
-    public Post mapPostFromFacebookData(Pair<FacebookDataItem, FacebookResponse> facebookResponseFacebookResponsePair) {
-        var facebookPostData = facebookResponseFacebookResponsePair.getLeft();
-        var facebookAttachments = facebookResponseFacebookResponsePair.getRight();
+    public Post mapPostFromFacebookData(Pair<FacebookDataItem, FacebookResponse> fbPair, Post post) {
+        FacebookDataItem facebookPostData = fbPair.getLeft();
+        FacebookResponse facebookAttachments = fbPair.getRight();
 
-        Post post = this.mapPostFromFacebookData(facebookPostData);
 
-        if(facebookAttachments.getData().size() < 1) {
-            return post;
+        if(facebookPostData.getMessage() != null) {
+            post.setDescription(facebookPostData.getMessage());
         }
 
-        if( facebookAttachments.getData().get(0).getSubattachments() == null) {
-
-            if(facebookAttachments.getData().get(0).getMedia() != null) {
-                return post.setFacebookImages(map(facebookAttachments.getData().get(0).getMedia().getImage()));
+        if (facebookAttachments.getData() == null || facebookAttachments.getData().isEmpty()) {
+            if(!post.getFacebookImages().isEmpty()){
+                post.getFacebookImages().clear();
             }
-
             return post;
         }
 
-        var images = facebookAttachments.getData().get(0)
-                .getSubattachments()
-                .getData().stream()
-                .map(FacebookDataItem::getMedia)
-                .map(FacebookPostMedia::getImage)
-                .map(this::map)
-                .flatMap(Collection::stream)
-                .toList();
+        var firstAttachment = facebookAttachments.getData().get(0);
 
-        return  post.setFacebookImages(images);
+        if (firstAttachment.getSubattachments() == null) {
+            if (firstAttachment.getMedia() != null) {
+                List<FacebookImage> images = map(firstAttachment.getMedia().getImage());
+                post.getFacebookImages().clear();
+                post.getFacebookImages().addAll(images);
+            }
+            return post;
+        }
+
+        List<FacebookImage> images = Stream.concat(
+                firstAttachment.getMedia() != null
+                        ? map(firstAttachment.getMedia().getImage()).stream()
+                        : Stream.empty(),
+                firstAttachment.getSubattachments() != null
+                        ? firstAttachment.getSubattachments().getData().stream()
+                        .map(FacebookDataItem::getMedia)
+                        .map(FacebookPostMedia::getImage)
+                        .map(this::map)
+                        .flatMap(Collection::stream)
+                        : Stream.empty()
+        ).collect(Collectors.toCollection(ArrayList::new));
+
+        post.getFacebookImages().clear();
+        post.getFacebookImages().addAll(images);
+
+        return post;
     }
 }

--- a/src/main/java/com/webdev/cosmo/cosmobackend/service/internal/posts/model/Post.java
+++ b/src/main/java/com/webdev/cosmo/cosmobackend/service/internal/posts/model/Post.java
@@ -6,8 +6,8 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
-import org.openapitools.model.FacebookPostImage;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Accessors(chain = true)
@@ -32,7 +32,19 @@ public class Post {
     @Column
     private List<Image> images;
 
-    @OneToMany(cascade = CascadeType.ALL)
-    @Column
-    private List<FacebookImage> facebookImages;
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinTable(
+            name = "posts_facebook_images",
+            joinColumns = @JoinColumn(name = "post_id"),
+            inverseJoinColumns = @JoinColumn(name = "facebook_images_id")
+    )
+    private List<FacebookImage> facebookImages = new ArrayList<>();
+
+    public List<FacebookImage> getFacebookImages() {
+        if (facebookImages == null) {
+            facebookImages = new ArrayList<>();
+        }
+        return facebookImages;
+    }
+
 }

--- a/src/main/java/com/webdev/cosmo/cosmobackend/service/internal/posts/repository/PostRepository.java
+++ b/src/main/java/com/webdev/cosmo/cosmobackend/service/internal/posts/repository/PostRepository.java
@@ -4,6 +4,9 @@ import com.webdev.cosmo.cosmobackend.service.internal.posts.model.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface PostRepository extends JpaRepository<Post, String> {
+    Optional<Post> findByProviderId(String id);
 }

--- a/src/main/java/com/webdev/cosmo/cosmobackend/service/internal/posts/service/PostsSyncExecutor.java
+++ b/src/main/java/com/webdev/cosmo/cosmobackend/service/internal/posts/service/PostsSyncExecutor.java
@@ -26,10 +26,10 @@ public class PostsSyncExecutor implements Executor {
     @Override
     public void execute() {
         List<FacebookDataItem> facebookDataItems = facebookDataItemProvider.get();
-
-        log.info("Successfully obtained {} items from facebook.", facebookDataItems.size());
         List<FacebookDataItem> facebookDataItemsToBeAdded = unsavedPostsExtractor.apply(facebookDataItems, postRepository.findAll());
-        postRepository.saveAll(postsFromDataItemsBuilder.apply(facebookDataItemsToBeAdded));
-//        log.info("Added ");
+        List<Post> postsToSave = postsFromDataItemsBuilder.apply(facebookDataItemsToBeAdded);
+
+        postRepository.saveAll(postsToSave);
     }
+
 }

--- a/src/main/java/com/webdev/cosmo/cosmobackend/service/internal/posts/service/builder/PostsFromDataItemsBuilder.java
+++ b/src/main/java/com/webdev/cosmo/cosmobackend/service/internal/posts/service/builder/PostsFromDataItemsBuilder.java
@@ -4,9 +4,12 @@ import com.webdev.cosmo.cosmobackend.service.common.FacebookClient;
 import com.webdev.cosmo.cosmobackend.service.internal.facebook.service.async.Cache;
 import com.webdev.cosmo.cosmobackend.service.internal.posts.mapper.PostMapper;
 import com.webdev.cosmo.cosmobackend.service.internal.posts.model.Post;
+import com.webdev.cosmo.cosmobackend.service.internal.posts.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
 import org.openapitools.model.FacebookDataItem;
+import org.openapitools.model.FacebookResponse;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -20,11 +23,25 @@ public class PostsFromDataItemsBuilder implements Function<List<FacebookDataItem
     private final Cache cache;
     private final PostMapper postMapper;
 
+    @Autowired
+    protected PostRepository postRepository;
+
     @Override
     public List<Post> apply(List<FacebookDataItem> facebookDataItems) {
         return facebookDataItems.stream()
-                .map(facebookDataItem -> Pair.of(facebookDataItem, facebookClient.getPostAttachments(facebookDataItem.getId(), cache.getPageAccessToken())))
-                .map(postMapper::mapPostFromFacebookData)
+                .map(facebookDataItem -> {
+                    FacebookResponse attachments = facebookClient.getPostAttachments(
+                            facebookDataItem.getId(),
+                            cache.getPageAccessToken()
+                    );
+
+                    Post post = postRepository.findByProviderId(facebookDataItem.getId())
+                            .orElseGet(() -> postMapper.mapPostFromFacebookData(facebookDataItem));
+
+                    return Pair.of(Pair.of(facebookDataItem, attachments), post);
+                })
+                .map(pair -> postMapper.mapPostFromFacebookData(pair.getLeft(), pair.getRight()))
                 .toList();
+
     }
 }

--- a/src/main/java/com/webdev/cosmo/cosmobackend/service/internal/posts/service/builder/UnsavedPostsExtractor.java
+++ b/src/main/java/com/webdev/cosmo/cosmobackend/service/internal/posts/service/builder/UnsavedPostsExtractor.java
@@ -1,20 +1,48 @@
 package com.webdev.cosmo.cosmobackend.service.internal.posts.service.builder;
 
 import com.webdev.cosmo.cosmobackend.service.internal.posts.model.Post;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.model.FacebookDataItem;
+import org.openapitools.model.FacebookPostImage;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 
+@Slf4j
 @Component
 public class UnsavedPostsExtractor implements BiFunction<List<FacebookDataItem>, List<Post>, List<FacebookDataItem>> {
 
     @Override
     public List<FacebookDataItem> apply(List<FacebookDataItem> facebookDataItems, List<Post> posts) {
-        return facebookDataItems.stream()
-                .filter(item -> posts.stream().noneMatch(post -> StringUtils.equals(item.getId(), post.getProviderId())))
-                .toList();
+        return facebookDataItems.stream().filter(item -> posts.stream().noneMatch(post -> {
+            if (!StringUtils.equals(post.getProviderId(), item.getId())) {
+                return false;
+            }
+
+            if (post.getDescription() != null && !post.getDescription().equals(item.getMessage())) {
+                return false;
+            }
+
+            List<FacebookPostImage> facebookPostImages = new ArrayList<>();
+
+            if (item.getMedia() != null && item.getMedia().getImage() != null) {
+                facebookPostImages.add(item.getMedia().getImage());
+            }
+
+            if (item.getSubattachments() != null) {
+                item.getSubattachments().getData().forEach(subItem -> {
+                    if (subItem.getMedia() != null && subItem.getMedia().getImage() != null) {
+                        facebookPostImages.add(subItem.getMedia().getImage());
+                    }
+                });
+            }
+
+            return facebookPostImages.size() == post.getFacebookImages().size() && post.getFacebookImages().stream().allMatch( local ->
+                    facebookPostImages.stream().anyMatch(fb -> local.getSrc().equals(fb.getSrc()))
+            );
+        })).toList();
     }
 }


### PR DESCRIPTION
This PR fixes an issue with expiring image links:

Existing posts now update correctly, preventing image URLs from becoming outdated.

Along with fixing image updates, other post fields are also properly updated during synchronization.